### PR TITLE
✨ chore: fix env var for domain and clean up SVG generation

### DIFF
--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -164,7 +164,7 @@ jobs:
       
       - name: "🔑 Generate Farcaster account association"
         env:
-            NEXT_PUBLIC_APP_DOMAIN: ${{ steps.deploy-temp.outputs.production_domain }}
+            NEXT_PUBLIC_APP_DOMAIN: ${{ steps.cleanup-projects.outputs.existing_project_name }}.vercel.app
             FARCASTER_FID: ${{ secrets.FARCASTER_FID }}
             FARCASTER_CUSTODY_ADDRESS: ${{ secrets.FARCASTER_CUSTODY_ADDRESS }}
             FARCASTER_CUSTODY_PRIVATE_KEY: ${{ secrets.FARCASTER_CUSTODY_PRIVATE_KEY }}
@@ -174,12 +174,8 @@ jobs:
       - name: "🎨 Generate SVG icons with gradients"
         run: |
           # Export domain URLs for SVG icon generation
-          PRODUCTION_DOMAIN="${{ steps.deploy-temp.outputs.production_domain }}"
-          export SCREENSHOT_URL="https://${PRODUCTION_DOMAIN}"
-          export NEXT_PUBLIC_APP_DOMAIN="$PRODUCTION_DOMAIN"
-          
+            
           echo "🎨 Generating SVG icons with gradient colors"
-          echo "Using production domain: $PRODUCTION_DOMAIN"
           node scripts/generate-svg-icons-with-gradient.js
 
 


### PR DESCRIPTION
Update Vercel deploy workflow to use the actual project domain
and simplify environment exports for SVG generation.

- Replace NEXT_PUBLIC_APP_DOMAIN value for Farcaster account
  association to use the existing project name from the cleanup
  step: set to "${{ steps.cleanup-projects.outputs.existing_project_name }}.vercel.app"
  so the generated association uses the correct production domain.
- Remove redundant PRODUCTION_DOMAIN and related exports when
  generating SVG icons and eliminate an unnecessary debug echo.
  Keep the SVG generation step focused on running the Node script.

This ensures the pipeline uses the correct domain during token
generation and removes dead/unneeded environment variable exports.