### PR TITLE
✨ chore(workflow): set NEXT_PUBLIC_APP_DOMAIN for SVG job

### DIFF
--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -172,6 +172,8 @@ jobs:
             echo "🔧 Generating Farcaster account association for domain: $NEXT_PUBLIC_APP_DOMAIN"
             node scripts/generate-farcaster-account-association.js generate
       - name: "🎨 Generate SVG icons with gradients"
+        env:
+            NEXT_PUBLIC_APP_DOMAIN: ${{ steps.cleanup-projects.outputs.existing_project_name }}.vercel.app
         run: |
           # Export domain URLs for SVG icon generation
             


### PR DESCRIPTION
Add environment variable injection for the "Generate SVG icons with
gradients" step in the Vercel deploy workflow. The step now receives
NEXT_PUBLIC_APP_DOMAIN set to the current project's domain derived from
cleanup-projects.outputs.existing_project_name. This ensures icon
generation can reference the correct domain during CI runs.