### PR TITLE
✨ chore(deploy): guard announce step behind flag

### DIFF
--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -282,9 +282,10 @@ jobs:
               // Don't fail the workflow if homepage update fails
             }
       - name: "📢 Announce deployment and favorite frame"
-        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master'
+        if: (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master') && env.deploy_this == 'true'
         env:
-             FARCASTER_BEARER_TOKEN: ${{ secrets.FARCASTER_BEARER_TOKEN }}
+          deploy_this: true
+          FARCASTER_BEARER_TOKEN: ${{ secrets.FARCASTER_BEARER_TOKEN }}
         run: |
                   PRODUCTION_URL="${{ steps.deploy-production.outputs.production_url }}"
                   # Extract domain from full URL for scripts that expect domain only


### PR DESCRIPTION
Only run the "Announce deployment and favorite frame" job when a
deployment actually occurred. The step previously executed
for main/master refs regardless, which could post announcements or
favorite frames even when deploys were skipped.

Add an env toggle (deploy_this) and require it in the job's if
condition so announcements only run when env.deploy_this == 'true'.
This prevents spurious notifications and aligns workflow behavior
with actual deployment outcomes.